### PR TITLE
THEIA-IDE for Ubuntu 16.04 (Mark-2)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -93,6 +93,8 @@ class TheiaIde(MycroftSkill):
                     url = 'https://github.com/andlo/theia-for-mycroft/releases/download/THEIA-for-Mycroft/theiaide-mark1.tgz'
             if platform == "mycroft_mark_1":
                 url = 'https://github.com/andlo/theia-for-mycroft/releases/download/THEIA-for-Mycroft/theiaide-mark1.tgz'
+            if platform == "mycroft_mark_2":
+                url = 'https://github.com/domcross/theia-for-mycroft/releases/download/THEIA-for-Mycroft/theiaide-mark2.tgz'
             try:
                 filename = wget.download(url, self.SafePath + '/theiaide.tgz')
                 self.log.info("Unpacking....")


### PR DESCRIPTION
I have succesfully build THEIA-IDE for Ubuntu 16.04 (which is/will be most likely the OS platform for the Mark-2).

The pre-built package "theiaide-mark2.tgz" will be currently downloaded from my forked repository "theia-for-mycroft". Feel free to pull the tgz-file from there to your own repository (then you must change the download URL in init.py of course).

NOTE: when building I had some issues with "yarn", the version pulled by apt-get was too old. I don't know if the same problems arises when the pre-built package is deployed by the theia-ide-skill...?
I had to install the current yarn-version as instructed [here](https://yarnpkg.com/en/docs/install#debian-stable):

`curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -`
`echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list`

`sudo apt-get update && sudo apt-get install yarn`